### PR TITLE
Implemented static constructors for DbContext and Globals to enforce …

### DIFF
--- a/ReserveBlockCore/Data/DbContext.cs
+++ b/ReserveBlockCore/Data/DbContext.cs
@@ -73,7 +73,7 @@ namespace ReserveBlockCore.Data
         public const string RSRV_DECSHOP = "rsrv_decshop";
         public const string RSRV_DECSHOPSTATE_TREI = "rsrv_decshopstate_trei";
        
-        public static void Initialize()
+        static DbContext()
         {
             var databaseLocation = Globals.IsTestNet != true ? "Databases" : "DatabasesTestNet";
             var mainFolderPath = Globals.IsTestNet != true ? "RBX" : "RBXTest";

--- a/ReserveBlockCore/Globals.cs
+++ b/ReserveBlockCore/Globals.cs
@@ -7,6 +7,13 @@ namespace ReserveBlockCore
 {
     public static class Globals
     {
+        static Globals()
+        {
+            var peerDb = Peers.GetAll();
+            BannedIPs = new ConcurrentDictionary<string, bool>(
+                peerDb.Find(x => x.IsBanned).ToArray().ToDictionary(x => x.PeerIP, x => true));
+        }
+
         #region Timers
 
         public static Timer? heightTimer; //timer for getting height from other nodes
@@ -78,7 +85,7 @@ namespace ReserveBlockCore
 
         public const int MaxPeers = 8;
         public static ConcurrentDictionary<string, int> ReportedIPs = new ConcurrentDictionary<string, int>();
-        public static ConcurrentDictionary<string, bool> BannedIPs = new ConcurrentDictionary<string, bool>();
+        public static ConcurrentDictionary<string, bool> BannedIPs;
         public static long LastSentBlockHeight = -1;
         public static DateTime? AdjudicatorConnectDate = null;
         public static DateTime? LastTaskSentTime = null;

--- a/ReserveBlockCore/Models/Peers.cs
+++ b/ReserveBlockCore/Models/Peers.cs
@@ -56,6 +56,16 @@ namespace ReserveBlockCore.Models
             var peer = peerDb.FindOne(x => x.PeerIP == ipAddress);
             peer.IsBanned = true;
             peerDb.Update(peer);
+
+            if (Globals.P2PPeerList.TryRemove(ipAddress, out var context))            
+                context.Abort();
+
+
+            if (Globals.AdjPeerList.TryRemove(ipAddress, out var context2))
+                context2.Abort();
+
+            if (Globals.Nodes.TryRemove(ipAddress, out NodeInfo node))
+                node.Connection.DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public static void UpdatePeerLastReach(Peers incPeer)

--- a/ReserveBlockCore/Models/Peers.cs
+++ b/ReserveBlockCore/Models/Peers.cs
@@ -49,6 +49,15 @@ namespace ReserveBlockCore.Models
             
         }
 
+        public static void BanPeer(string ipAddress)
+        {
+            Globals.BannedIPs[ipAddress] = true;
+            var peerDb = Peers.GetAll();
+            var peer = peerDb.FindOne(x => x.PeerIP == ipAddress);
+            peer.IsBanned = true;
+            peerDb.Update(peer);
+        }
+
         public static void UpdatePeerLastReach(Peers incPeer)
         {
             var peers = GetAll();

--- a/ReserveBlockCore/P2P/P2PClient.cs
+++ b/ReserveBlockCore/P2P/P2PClient.cs
@@ -160,7 +160,7 @@ namespace ReserveBlockCore.P2P
                             var prevPrevTime = Interlocked.Exchange(ref node.SecondPreviousReceiveTime, node.PreviousReceiveTime);
                             if (now - prevPrevTime < 15000)
                             {
-                                Globals.BannedIPs[IPAddress] = true;
+                                Peers.BanPeer(IPAddress);
                                 await RemoveNode(node);
                                 return;
                             }

--- a/ReserveBlockCore/P2P/P2PClient.cs
+++ b/ReserveBlockCore/P2P/P2PClient.cs
@@ -42,8 +42,8 @@ namespace ReserveBlockCore.P2P
         }
         private static async Task RemoveNode(NodeInfo node)
         {
-            Globals.Nodes.TryRemove(node.NodeIP, out NodeInfo test);            
-            await node.Connection.DisposeAsync();            
+            if(Globals.Nodes.TryRemove(node.NodeIP, out NodeInfo test))
+                await node.Connection.DisposeAsync();            
         }
 
         #endregion
@@ -160,8 +160,7 @@ namespace ReserveBlockCore.P2P
                             var prevPrevTime = Interlocked.Exchange(ref node.SecondPreviousReceiveTime, node.PreviousReceiveTime);
                             if (now - prevPrevTime < 15000)
                             {
-                                Peers.BanPeer(IPAddress);
-                                await RemoveNode(node);
+                                Peers.BanPeer(IPAddress);                                
                                 return;
                             }
                             Interlocked.Exchange(ref node.PreviousReceiveTime, now);                            

--- a/ReserveBlockCore/P2P/P2PServer.cs
+++ b/ReserveBlockCore/P2P/P2PServer.cs
@@ -74,11 +74,9 @@ namespace ReserveBlockCore.P2P
             if (Globals.MessageLocks.TryGetValue(ipAddress, out var Lock))
             {                               
                 var prev = Interlocked.Exchange(ref Lock.LastRequestTime, now);               
-                if (Lock.ConnectionCount > 20)
-                {
-                    Peers.BanPeer(ipAddress);                    
-                    context.Abort();
-                }
+                if (Lock.ConnectionCount > 20)                
+                    Peers.BanPeer(ipAddress);                                        
+                
                 if (Lock.BufferCost + sizeCost > 5000000)
                 {
                     throw new HubException("Too much buffer usage.  Message was dropped.");

--- a/ReserveBlockCore/P2P/P2PServer.cs
+++ b/ReserveBlockCore/P2P/P2PServer.cs
@@ -76,7 +76,7 @@ namespace ReserveBlockCore.P2P
                 var prev = Interlocked.Exchange(ref Lock.LastRequestTime, now);               
                 if (Lock.ConnectionCount > 20)
                 {
-                    Globals.BannedIPs[ipAddress] = true;
+                    Peers.BanPeer(ipAddress);                    
                     context.Abort();
                 }
                 if (Lock.BufferCost + sizeCost > 5000000)

--- a/ReserveBlockCore/Services/BlockValidatorService.cs
+++ b/ReserveBlockCore/Services/BlockValidatorService.cs
@@ -58,8 +58,8 @@ namespace ReserveBlockCore.Services
                         var (block, ipAddress) = blockInfo;
                         var result = await ValidateBlock(block, true);                        
                         if (!result)
-                        {
-                            Globals.BannedIPs[ipAddress] = true;
+                        {                            
+                            Peers.BanPeer(ipAddress);
                             ErrorLogUtility.LogError("Banned IP address: " + ipAddress + " at height " + height, "ValidateBlocks");
                             if(Globals.Nodes.TryRemove(ipAddress, out var node))
                                 await node.Connection.DisposeAsync();                            

--- a/ReserveBlockCore/Services/StartupService.cs
+++ b/ReserveBlockCore/Services/StartupService.cs
@@ -49,8 +49,7 @@ namespace ReserveBlockCore.Services
         internal static void StartupDatabase()
         {
             //Establish block, wallet, ban list, and peers db
-            Console.WriteLine("Initializing Reserve Block Database...");
-            DbContext.Initialize();
+            Console.WriteLine("Initializing Reserve Block Database...");            
         }
 
         internal static void HDWalletCheck()


### PR DESCRIPTION
…the order of static variable initialization.  Banned Peers are now saved to the DB and cached on start-up.