### PR TITLE
Fixed bug in Command<T>(this ILiteCollection<T> col, Action cmd)

### DIFF
--- a/ReserveBlockCore/Extensions/SafeDbExtensions.cs
+++ b/ReserveBlockCore/Extensions/SafeDbExtensions.cs
@@ -45,6 +45,7 @@ namespace ReserveBlockCore.Extensions
             SemaphoreSlim slim = null;
             try
             {
+                slim = col.GetSlim();
                 slim.Wait();
                 cmd();
             }

--- a/ReserveBlockCore/ReserveBlockCore.csproj
+++ b/ReserveBlockCore/ReserveBlockCore.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.0.5" />
     <PackageReference Include="LiteDB" Version="5.0.12" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/ReserveBlockCore/ReserveBlockCore.csproj
+++ b/ReserveBlockCore/ReserveBlockCore.csproj
@@ -30,7 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.0.5" />
     <PackageReference Include="LiteDB" Version="5.0.12" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />


### PR DESCRIPTION
This will reduce memory allocations and won't leave leftovers in a concurrent dictionary.

Also please note that there is a bug in `public static void Command<T>(this ILiteCollection<T> col, Action cmd)` which I left as is...  this will not run the `cmd()` but just log because the SemaphoreSlim is being set to null so you can't wait or release it. I'm not sure what the intentions were so I'm not sure if it should use the same code as the other one I changed in this PR.

Perhaps @AlexanderSWilliams can shed some light on this.